### PR TITLE
feature: 공용 Filter Rating 라디오 리스트 제작 #44

### DIFF
--- a/src/components/ui/FilterRating.tsx
+++ b/src/components/ui/FilterRating.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Field, Label, Radio, RadioGroup } from '@headlessui/react';
 import { useState } from 'react';
 


### PR DESCRIPTION
# 작업 내역
- #44 
- headlessui 를 사용하여 제작 되었습니다.
- value는 답변 오는 것을 보고 추후에 변경 예정입니다.
- 라디오 그룹의 name은 `rating` 으로 설정해뒀습니다.
- 기능 구현시 방법에 따라 수정이 필요할 수도 있습니다.

## 스크린샷
<img width="147" height="189" alt="image" src="https://github.com/user-attachments/assets/c250234b-3e4f-45ae-b88d-59c77d3d097d" />

