### PR TITLE
feat: 별점 집계바 컴포넌트,별점 인풋 컴포넌트 구현(#82)

### DIFF
--- a/src/components/ui/RangeSlider/RatingRangeBars.tsx
+++ b/src/components/ui/RangeSlider/RatingRangeBars.tsx
@@ -1,0 +1,39 @@
+import { AvgRatings } from '@/types/keyboardTypes';
+
+interface Props {
+  reviewCount: number;
+  avgRatings: AvgRatings;
+}
+
+const RatingRangeBars = ({ reviewCount, avgRatings }: Props) => {
+  const RATING_LABEL = ['5', '4', '3', '2', '1'];
+  const FLEX_STYLE = 'flex gap-4 items-center my-2';
+  const calcPercentage = (label: keyof AvgRatings): number => {
+    return (avgRatings[label] / reviewCount) * 100;
+  };
+
+  return (
+    <div className='whitespace-nowrap text-gray-500 font-medium leading-[26px] w-full md:w-70'>
+      {RATING_LABEL.map((label) => (
+        <div key={label} className={FLEX_STYLE}>
+          {label}점 <RangeBar percentage={calcPercentage(label as keyof AvgRatings)} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RatingRangeBars;
+
+const RangeBar = ({ percentage }: { percentage: number }) => {
+  return (
+    <div className='w-full'>
+      <div className='relative w-full h-[6px] rounded-[50px] bg-gray-100'>
+        <div
+          className='absolute w-full h-[6px] rounded-[50px] bg-primary'
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/StarRatingInput.tsx
+++ b/src/components/ui/StarRatingInput.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Image from 'next/image';
+
+import { Button } from '@headlessui/react';
+import { useState } from 'react';
+
+interface Props {
+  className?: string;
+  updater: (rating: number) => void;
+}
+
+const StarRatingInput = ({ className, updater }: Props) => {
+  const [rating, setRating] = useState(0);
+  const [hoveringRating, setHoveringRating] = useState(0);
+  const [isHovering, setIsHovering] = useState(false);
+
+  const STAR_VALUES = [1, 2, 3, 4, 5];
+  const FILLED_STAR_URL = '/images/StarRatingIcon.svg';
+  const EMPTY_STAR_URL = '/images/EmptyStarIcon.svg';
+
+  const chooseComparedValue = (rating: number, hoveringRating: number): number =>
+    isHovering ? hoveringRating : rating;
+
+  const rateStar = (value: number): string => {
+    return value <= chooseComparedValue(rating, hoveringRating) ? FILLED_STAR_URL : EMPTY_STAR_URL;
+  };
+
+  return (
+    <div className={className}>
+      {STAR_VALUES.map((star) => (
+        <Button
+          key={star}
+          onClick={() => {
+            setRating(star);
+            updater(star);
+          }}
+          onMouseOver={() => {
+            setIsHovering(true);
+            setHoveringRating(star);
+          }}
+          onMouseOut={() => {
+            setIsHovering(false);
+          }}
+        >
+          <Image
+            src={rateStar(star)}
+            alt={rateStar(star) === FILLED_STAR_URL ? '채워진 별 아이콘' : '빈 별 아이콘'}
+            width={32}
+            height={32}
+          />
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default StarRatingInput;


### PR DESCRIPTION
## 작업 내역
close #82 

별점 집계 컴포넌트는 상세 페이지만 사용하니 가볍게 보시면 될 것 같습니다.
(각 별점 수 / 총 리뷰수) 를 계산해 퍼센티지를 보라색 바의 width로 줍니다.

별점 인풋 컴포넌트는 
- className?: string;
- updater: (rating: number) => void;
컨테이너에 줄 수 있는 className과 별점 값을 업데이트할 함수 두 개를 props로 받습니다.

## 스크린샷 (선택)
<img width="238" height="116" alt="스크린샷 2025-07-24 222707" src="https://github.com/user-attachments/assets/b707e9f8-5b3e-473d-9974-49ece1af48bb" />
<br >
<img width="121" height="28" alt="스크린샷 2025-07-24 222640" src="https://github.com/user-attachments/assets/7cf1b48a-a797-4404-8fb8-33790e434432" />
<br >
<img width="123" height="22" alt="스크린샷 2025-07-24 222622" src="https://github.com/user-attachments/assets/7fda5203-f870-407b-bbf8-8baa07d7902b" />
