### PR TITLE
Fix: 로그인 권한에 따른 페이지 리다이렉트 오작동 수정

### DIFF
--- a/src/components/feature/RequireAuth.tsx
+++ b/src/components/feature/RequireAuth.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { ReactNode, useEffect, useState } from 'react';
 
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
-import { LOGIN_PAGE, SIGNUP_PAGE, KEYBOARD_LIST_PAGE } from '@/constants';
+import { LOGIN_PAGE, SIGNUP_PAGE, KEYBOARD_LIST_PAGE, KAKAO_LOGIN_PAGE } from '@/constants';
 import { AxiosApiAuth } from '@/lib/api/axios';
 import { tokenService } from '@/lib/api/tokenService';
 
@@ -15,10 +15,13 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
 
   const router = useRouter();
   const pathname = usePathname();
-  const PUBLIC_PATHS = [LOGIN_PAGE, SIGNUP_PAGE, '/', KEYBOARD_LIST_PAGE];
-  const isPublicPath = PUBLIC_PATHS.includes(pathname) || pathname.startsWith('/oauth/kakao'); // 로그인 하지 않아도 접근 가능한 페이지: 랜딩, 로그인, 회원가입, 소셜 로그인, 키보드 목록 페이지
+  // 로그인 하지 않아도 접근 가능한 페이지: 랜딩, 로그인, 회원가입, 소셜 로그인, 키보드 목록 페이지
+  const PUBLIC_PATHS = ['/', KEYBOARD_LIST_PAGE];
+  const isPublicPath = PUBLIC_PATHS.includes(pathname);
+  const AUTH_PATHS = [LOGIN_PAGE, SIGNUP_PAGE, KAKAO_LOGIN_PAGE];
+  const isAuthPath = AUTH_PATHS.includes(pathname);
 
-  // refreshToken 기반 accessToken 재발급 받기
+  // refreshToken 기반 accessToken 재발급 함수
   const refreshAccessToken = async (refreshToken: string) => {
     const auth = new AxiosApiAuth();
 
@@ -35,12 +38,15 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  // 로그인, 회원가입, 카카오 로그인 경로만 로그인 이후 메인으로 리다이렉트
+  // 메인, 키보드 페이지: 리다이렉트 X. 그대로 보여주기.
   useEffect(() => {
     const checkAndRefreshToken = async () => {
       const accessToken = tokenService.getAccessToken();
       const refreshToken = tokenService.getRefreshToken();
 
-      if (isPublicPath) {
+      if (isAuthPath) {
+        // Auth(로그인/회원가입/카카오 로그인) 페이지: 로그인 유저는 메인으로 리다이렉트
         if (accessToken) {
           router.replace('/');
           return;
@@ -58,7 +64,12 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
           setIsAuthChecked(true);
         }
         return;
+      } else if (isPublicPath) {
+        // 로그인 권한 필요 없는 공개 페이지 (메인, 키보드 목록 페이지): 권한 검사 없이 바로 페이지 본문 리턴
+        setIsAuthChecked(true);
+        return;
       } else {
+        // 그외 권한 필요 페이지 (키보드 상세, 프로필 페이지)
         if (!accessToken) {
           if (!refreshToken) {
             router.replace(LOGIN_PAGE);
@@ -80,7 +91,7 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
     };
 
     checkAndRefreshToken();
-  }, [pathname, router, isPublicPath]);
+  }, [pathname, router, isAuthPath, isPublicPath]);
 
   if (!isAuthChecked) return isRefreshing ? <LoadingSpinner text='로그인 확인중...' /> : null;
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,3 +11,4 @@ export const REFRESH_TOKEN_KEY = 'refreshToken';
 export const LOGIN_PAGE = '/login';
 export const SIGNUP_PAGE = '/signUp';
 export const KEYBOARD_LIST_PAGE = '/keyboards';
+export const KAKAO_LOGIN_PAGE = '/oauth/kakao';


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- RequireAuth 일부 수정
  - 로그인 권한이 필요 없는 '키보드 목록 페이지'에 로그인 후 접근하면 메인으로 자동 리다이렉트 되는 문제 수정 

## 전달 사항 (선택)
- 라우팅 로직 정리
  1. 로그인 권한이 필요 없고, 로그인 후 접근하면 메인으로 리다이렉트 되는 페이지: 로그인, 회원가입, 카카오 로그인 페이지
      - 로그인 전: 모두 접근 가능
      - 로그인 후: 메인으로 리다이렉트됨 
  2. 로그인 권한이 필요한 페이지: 키보드 상세, 마이 프로필 페이지
      - 로그인 전: 접근 불가
      - 로그인 후: 접근 가능
  3. 로그인 권한이 필요 없고, 리다이렉트도 필요 없는 페이지: 메인, 키보드 목록 페이지
      - 로그인 전: 접근 가능
      - 로그인 후: 접근 가능

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->


## 스크린샷 (선택)
