### PR TITLE
#118 로그인 권한 페이지 - 로그인 후 자동 리다이렉트 

### DIFF
--- a/src/components/feature/LoginForm.tsx
+++ b/src/components/feature/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Field } from '@headlessui/react';
 import { AxiosError } from 'axios';
@@ -25,6 +25,7 @@ const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 const LoginForm = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const auth = new AxiosApiAuth();
 
   const {
@@ -39,7 +40,15 @@ const LoginForm = () => {
 
     try {
       await auth.signInByEmail(email, password);
-      router.push('/');
+
+      // 쿼리 파라미터에서 redirect_url 가져오기 (로그인 후 리다이렉트 처리)
+      const redirectUrl = searchParams.get('redirect_url');
+
+      if (redirectUrl) {
+        router.replace(redirectUrl);
+      } else {
+        router.push('/');
+      }
     } catch (error) {
       const err = error as AxiosError;
       if (err.response?.status === 400) {

--- a/src/components/feature/RequireAuth.tsx
+++ b/src/components/feature/RequireAuth.tsx
@@ -69,10 +69,11 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
         setIsAuthChecked(true);
         return;
       } else {
-        // 그외 권한 필요 페이지 (키보드 상세, 프로필 페이지)
+        // 그외 권한 필요 페이지 (키보드 상세, 프로필 페이지): 로그인 후 해당 페이지로 리다이렉트
         if (!accessToken) {
           if (!refreshToken) {
-            router.replace(LOGIN_PAGE);
+            const url = `${LOGIN_PAGE}?redirect_url=${encodeURIComponent(pathname)}`;
+            router.replace(url);
             return;
           }
 


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- 마이 프로필 페이지, 키보드 상세 페이지와 같은 로그인 권한이 필요한 페이지에 비회원으로 접속했을 때는 로그인 페이지로 리다이렉트하고, 로그인 성공하면 다시 해당 페이지로 리다이렉트 
  - 원래는 로그인 성공하면 무조건 메인 페이지로 이동되었음 
  - next의 useSearchParams 사용 

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->
- 요구사항은 아닌데, 사용자 경험상 필요한 기능이라고 생각되어서 구현했습니다. 

## 스크린샷 (선택)
