### PR TITLE
#39 404 페이지 + 3초 후 리다이렉트, 런타임 전역 에러 ui용 페이지 추가

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const GlobalError = ({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) => {
+  useEffect(() => {
+    console.error('런타임 전역 에러 발생: ', error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <main>
+          <h2>일시적인 문제가 발생했습니다.</h2>
+          <p>잠시 후 다시 시도해 주세요.</p>
+          <button onClick={() => reset()}>다시 시도하기</button>
+        </main>
+      </body>
+    </html>
+  );
+};
+
+export default GlobalError;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,29 @@
   --shadow-primary: 0 2px 20px 0 rgba(0, 0, 0, 0.04);
 }
 
+@layer utilities {
+  .fade-up {
+    opacity: 0;
+    transform: translateY(1rem);
+    animation: fadeUp 0.5s ease-out forwards;
+  }
+
+  .fade-up-delay-1 {
+    animation-delay: 0.2s;
+  }
+
+  .fade-up-delay-2 {
+    animation-delay: 0.3s;
+  }
+
+  @keyframes fadeUp {
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}
+
 @layer components {
   .input {
     @apply w-full px-5 pr-12 border py-2.5 text-md sm:rounded-xl

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,20 +1,28 @@
 'use client';
 
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const NotFound = () => {
   const router = useRouter();
+  const [counter, setCounter] = useState<number>(3);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      router.push('/');
-    }, 3000);
+    if (counter <= 0) return;
 
-    return () => clearTimeout(timer);
-  }, [router]);
+    const intervalCounter = setInterval(() => {
+      setCounter((prev) => prev - 1);
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalCounter);
+    };
+  }, [counter]);
+
+  useEffect(() => {
+    if (counter === 1) router.push('/');
+  }, [router, counter]);
 
   return (
     <section className='flex flex-col items-center justify-center h-screen bg-gray-100 text-center'>
@@ -23,7 +31,8 @@ const NotFound = () => {
       </h2>
       <p className='text-[--color-gray-500] mb-6 fade-up fade-up-delay-2'>
         페이지를 찾을 수 없어요! <br />
-        <span className='font-medium text-[--color-primary]'>3초 뒤 메인 페이지</span>로 이동합니다.
+        <span className='font-medium text-[--color-primary]'>{counter}초 뒤 메인 페이지</span>로
+        이동합니다.
       </p>
     </section>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import { useEffect } from 'react';
+
+const NotFound = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push('/');
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <section className='flex flex-col items-center justify-center h-screen bg-gray-100 text-center'>
+      <h2 className='text-7xl leading-none mb-6 text-primary font-bold fade-up fade-up-delay-1 bg-gradient-to-r from-[#8642db] to-[#f1e0fc] bg-clip-text text-transparent'>
+        404 Not Found
+      </h2>
+      <p className='text-[--color-gray-500] mb-6 fade-up fade-up-delay-2'>
+        페이지를 찾을 수 없어요! <br />
+        <span className='font-medium text-[--color-primary]'>3초 뒤 메인 페이지</span>로 이동합니다.
+      </p>
+    </section>
+  );
+};
+
+export default NotFound;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -29,10 +29,9 @@ const NotFound = () => {
       <h2 className='text-7xl leading-none mb-6 text-primary font-bold fade-up fade-up-delay-1 bg-gradient-to-r from-[#8642db] to-[#f1e0fc] bg-clip-text text-transparent'>
         404 Not Found
       </h2>
-      <p className='text-[--color-gray-500] mb-6 fade-up fade-up-delay-2'>
+      <p className='text-gray-800 mb-6 fade-up fade-up-delay-2'>
         페이지를 찾을 수 없어요! <br />
-        <span className='font-medium text-[--color-primary]'>{counter}초 뒤 메인 페이지</span>로
-        이동합니다.
+        <b className='text-primary'>{counter}</b>초 뒤 메인 페이지 로 이동합니다.
       </p>
     </section>
   );

--- a/src/components/feature/LoginForm.tsx
+++ b/src/components/feature/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { Field } from '@headlessui/react';
 import { AxiosError } from 'axios';
@@ -25,6 +25,7 @@ const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 const LoginForm = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const auth = new AxiosApiAuth();
 
   const {
@@ -39,7 +40,15 @@ const LoginForm = () => {
 
     try {
       await auth.signInByEmail(email, password);
-      router.push('/');
+
+      // 쿼리 파라미터에서 redirect_url 가져오기 (로그인 후 리다이렉트 처리)
+      const redirectUrl = searchParams.get('redirect_url');
+
+      if (redirectUrl) {
+        router.replace(redirectUrl);
+      } else {
+        router.push('/');
+      }
     } catch (error) {
       const err = error as AxiosError;
       if (err.response?.status === 400) {

--- a/src/components/feature/RequireAuth.tsx
+++ b/src/components/feature/RequireAuth.tsx
@@ -69,10 +69,11 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
         setIsAuthChecked(true);
         return;
       } else {
-        // 그외 권한 필요 페이지 (키보드 상세, 프로필 페이지)
+        // 그외 권한 필요 페이지 (키보드 상세, 프로필 페이지): 로그인 후 해당 페이지로 리다이렉트
         if (!accessToken) {
           if (!refreshToken) {
-            router.replace(LOGIN_PAGE);
+            const url = `${LOGIN_PAGE}?redirect_url=${encodeURIComponent(pathname)}`;
+            router.replace(url);
             return;
           }
 


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- `not-found.tsx` 페이지 추가
  - 없는 페이지 접근 시 `NotFound` 페이지 표시 + 3초 후 메인으로 리다이렉트 
- `global-error.tsx` 페이지 추가
  - 런타임 에러 발생 시 fallback UI를 처리해주는 컴포넌트라고 하네요.. 스프린트 미션에서 피드백 받은 걸 한번 적용해보았습니다.
  이번에 처음 써보는데, 런타임 에러가 발생하면 빈 페이지 대신에 해당 에러가 뜬 컴포넌트에만 fallback UI를 표시해주는 것 같습니다. 진행에 별로 도움 안되면 추후 삭제해도 될 것 같습니다.

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

## 스크린샷 (선택)
<img width="2537" height="1305" alt="스크린샷 2025-07-26 오전 12 51 37" src="https://github.com/user-attachments/assets/ef2692f2-bc84-4a22-8c41-1ab003e13849" />
