### PR TITLE
#127

### DIFF
--- a/src/hooks/useImageUpload.tsx
+++ b/src/hooks/useImageUpload.tsx
@@ -1,0 +1,65 @@
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
+
+import { apiClient } from '@/lib/api/apiClient';
+
+const MAX_SIZE = 1024 * 1024 * 5; // 5MB
+
+const useImageUpload = () => {
+  const [isUploading, setIsUploading] = useState(false);
+  const fileRef = useRef<null | HTMLInputElement>(null);
+  const [uploadImage, setUploadImage] = useState<File | null>(null);
+
+  // 이미지 업로드 함수
+  const fetchImage = async (file: File): Promise<string | undefined> => {
+    try {
+      const URL = `/${process.env.NEXT_PUBLIC_TEAM}/images/upload`;
+
+      // 한글 파일명 오류 방지 인코딩
+      const encodingFileName = encodeURIComponent(file.name);
+      const encodingFile = new File([file], encodingFileName, {
+        type: file.type,
+      });
+
+      const formData = new FormData();
+      formData.append('image', encodingFile);
+
+      const { data } = await apiClient.post(URL, formData);
+
+      return data.url;
+    } catch (error) {
+      console.error(error);
+    } finally {
+      // setIsUploading(false);
+      setIsUploading(() => false);
+    }
+  };
+
+  // input file onChange
+  const handleChangeImage = (
+    e: ChangeEvent<HTMLInputElement>,
+  ): Promise<string | undefined> | undefined => {
+    if (!e.target.files) return; // 파일 객체 없을 때
+    if (!e.target.files.length) return; // 이미지 업로드 취소시
+
+    const file = e.target.files[0];
+
+    // 이미지 용량 검증
+    if (file.size > MAX_SIZE) {
+      alert('사진 최대 용량은 5MB입니다.'); // 추후에 토스트로 적용해봐도 좋을 것 같음.
+      return;
+    }
+
+    setUploadImage(file);
+    setIsUploading(() => true);
+    return fetchImage(file);
+  };
+
+  useEffect(() => {
+    // 인풋 초기화
+    if (fileRef.current?.value) fileRef.current.value = '';
+  }, [uploadImage]);
+
+  return { uploadImage, handleChangeImage, fileRef, isUploading };
+};
+
+export default useImageUpload;


### PR DESCRIPTION
## 작업 내역
- #127 
- 이미지 업로드 api
- 최대 용량 검증
- 한글명 파일 인코딩

## 전달 사항
- 이미지 업로드 API는 class로 분리하기가 좀 애매한거 같아서 커스텀훅에 포함했습니다.
- 피그마 확인하니깐, 이미지는 딱 하나씩만 받는 것 같아서 배열 처리는 하지 않았습니다.
- 다른 예외 처리 할 게 있으면 알려주시면 감사하겠습니다!

## 반환값
- `uploadImage` : 키보드 등록하기 폼에서 프리뷰가 들어가는 것 같아서 File 타입으로 반환.
- `handleChangeImage` : file input에 onChange에 들어갈 함수
- fileRef : file input에 적용할 ref
- isUploading : 업로드 진행 중일때 로딩 스피너를 보여줄 용도.
