### PR TITLE
#86 화면크기가 작아질시 header tag의 내부 패딩유지

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,6 @@ const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) =>
           <UserThumbnail imgSrc={imgSrc} />
         ) : (
           <>
-            {' '}
             <Link href='/login'>로그인</Link>
             <Link href='/signUp'>회원가입</Link>
           </>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,11 +8,12 @@ interface HeaderProps {
 
 const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) => {
   return (
-    <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white px-[79px] py-[25px] '>
+    // <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white px-[79px] py-[25px] '>
+    <header className='mx-4 lg:mx-auto my-5 flex lg:max-w-[1140px] items-center justify-between bg-black rounded-2xl text-white px-5 py-4 md:py-[25px] md:px-[60px]'>
       <Link href='/' className='font-bold text-xl'>
         tadak
       </Link>
-      <div className='flex items-center gap-10 font-medium'>
+      <div className='flex items-center gap-5 md:gap-10 font-medium'>
         {loginStatus ? (
           <UserThumbnail imgSrc={imgSrc} />
         ) : (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) =>
       <Link href='/' className='font-bold text-xl'>
         tadak
       </Link>
-      <div className='flex items-center gap-5 md:gap-10 font-medium'>
+      <div className='flex items-center gap-5 md:gap-10 font-medium text-md md:text-base'>
         {loginStatus ? (
           <UserThumbnail imgSrc={imgSrc} />
         ) : (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,7 +8,7 @@ interface HeaderProps {
 
 const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) => {
   return (
-    <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white md:px-[79px] md:py-[25px] '>
+    <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white px-[79px] py-[25px] '>
       <Link href='/' className='font-bold text-xl'>
         tadak
       </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,7 +9,7 @@ interface HeaderProps {
 const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) => {
   return (
     // <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white px-[79px] py-[25px] '>
-    <header className='mx-4 lg:mx-auto my-5 flex lg:max-w-[1140px] items-center justify-between bg-black rounded-2xl text-white px-5 py-4 md:py-[25px] md:px-[60px]'>
+    <header className='mx-4 lg:mx-auto my-5 flex lg:max-w-[1140px] items-center justify-between bg-black rounded-xl md:rounded-2xl text-white px-5 h-[50px] md:h-[70px] md:px-[60px]'>
       <Link href='/' className='font-bold text-xl'>
         tadak
       </Link>


### PR DESCRIPTION
## 작업 내역

header tag의 m:px, m:py를 각각 px, py로 변경

## 전달 사항 (선택)

아래 화면 크기 변화에 따른 모양 참고해주세요.

## 스크린샷 (선택)

너비 : 1001px

<img width="1033" height="370" alt="스크린샷 2025-07-27 오후 3 09 33" src="https://github.com/user-attachments/assets/4bdf0df7-1b18-4dab-ad59-b7b8e6beb5fa" />


너비 : 639px

<img width="655" height="329" alt="스크린샷 2025-07-27 오후 3 10 31" src="https://github.com/user-attachments/assets/c82747a1-fc10-48d2-b65c-1292dc746a64" />
