### PR TITLE
(#152) feat: 헤더 sticky 적용, 상세 페이지 디자인 수정, useSticky 훅 분리

### DIFF
--- a/src/app/(global)/keyboards/[keyboardid]/page.tsx
+++ b/src/app/(global)/keyboards/[keyboardid]/page.tsx
@@ -14,7 +14,6 @@ const KeyboardDetailsPage = () => {
   const [keyboardInfo, setKeyboardInfo] = useState<KeyboardDetailType | null>(null);
   const params = useParams();
   const { keyboardid } = params;
-  console.log(keyboardid);
 
   const getKeyboardInfo = async () => {
     try {
@@ -35,7 +34,7 @@ const KeyboardDetailsPage = () => {
   }
 
   return (
-    <main className='max-w-285 px-4 pt-[30px] pb-10 md:px-5 lg:px-0 md:pt-10 md:pb-20 lg:pt-10 lg:mx-auto'>
+    <main className='lg:max-w-285 px-4 pt-[30px] pb-10 md:px-5 lg:px-0 md:pt-10 md:pb-20 lg:pt-10 lg:mx-auto'>
       <KeyboardInfoCard keyboardInfo={keyboardInfo} />
       <div className='lg:flex lg:items-start lg:gap-15 lg:justify-between'>
         <RatingsInfo keyboardInfo={keyboardInfo} />

--- a/src/components/feature/keyboardDetails/KeyboardInfoCard.tsx
+++ b/src/components/feature/keyboardDetails/KeyboardInfoCard.tsx
@@ -11,13 +11,14 @@ interface Props {
 const KeyboardInfoCard = ({ keyboardInfo }: Props) => {
   const { image, name, region, price } = keyboardInfo;
 
+  //이 부분 개발 끝나고 지워줘야 함
   const imageSlice = image.split('/');
   const lastImageURL = image.split('/')[imageSlice.length - 1];
   const encodedImage = encodeURIComponent(lastImageURL);
   const newImageSrc = image.replace(lastImageURL, encodedImage);
 
   return (
-    <section className='flex items-center gap-7 md:gap-15 lg:gap-21 border-1 border-gray-300 rounded-xl w-full md:max-w-200 lg:max-w-285 min-h-53 md:min-h-65 pl-5 pr-7 md:px-15 md:mx-auto md:mb-10 lg:mb-15'>
+    <section className='flex items-center gap-7 md:gap-15 lg:gap-21 border-1 border-gray-300 rounded-xl w-full md:max-w-285 min-h-53 md:min-h-65 pl-5 pr-7 md:px-15 md:mx-auto md:mb-10 lg:mb-15'>
       <div className='relative shrink-0 w-25 md:w-35 md:self-end'>
         <KeyboardThumbnail
           className='md:w-[80%] md:mx-auto'

--- a/src/components/feature/keyboardDetails/RatingsInfo.tsx
+++ b/src/components/feature/keyboardDetails/RatingsInfo.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { useCallback, useEffect, useRef, useState } from 'react';
 
 import ButtonDefault from '@/components/ui/ButtonDefault';
 import RatingRangeBars from '@/components/ui/RangeSlider/RatingRangeBars';
 import StarRating from '@/components/ui/StarRating';
+import useSticky from '@/hooks/useSticky';
 import { KeyboardDetailType } from '@/types/keyboardTypes';
 import { formatPrice, formatRating } from '@/utils/formatters';
 import { cn } from '@/utils/style';
@@ -12,33 +12,12 @@ interface Props {
   keyboardInfo: KeyboardDetailType;
 }
 
+const STICKY_TOP = 50;
+const TABLET_STICKY_TOP = 70;
+
 const RatingsInfo = ({ keyboardInfo }: Props) => {
-  const [isFixedOnTop, setIsFixedOnTop] = useState(false);
-  const stickyRef = useRef<HTMLElement | null>(null);
+  const { isFixedOnTop, stickyRef } = useSticky(STICKY_TOP, TABLET_STICKY_TOP);
   const { avgRating, reviewCount, avgRatings } = keyboardInfo;
-
-  const handleScroll = useCallback(() => {
-    const rect = stickyRef.current?.getBoundingClientRect();
-    const THRESHOLD = 1;
-
-    if (!rect) {
-      return;
-    }
-
-    if (rect.y < THRESHOLD) {
-      setIsFixedOnTop(true);
-    } else {
-      setIsFixedOnTop(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [handleScroll]);
 
   if (reviewCount === 0) {
     return;
@@ -48,13 +27,13 @@ const RatingsInfo = ({ keyboardInfo }: Props) => {
     <section
       ref={stickyRef}
       className={cn(
-        'sticky top-0 lg:order-1 bg-white lg:shadow-none pt-5 pb-[10px] px-4 lg:p-0 lg:pt-5 -mx-5 lg:m-0 z-1',
+        'sticky top-[50px] md:top-[70px] lg:order-1 bg-white lg:shadow-none pt-5 pb-[10px] px-4 lg:p-0 lg:pt-5 -mx-5 lg:m-0 z-1',
         {
           'shadow-[0_5px_10px_rgba(0,0,0,0.04)]': isFixedOnTop,
         },
       )}
     >
-      <div className='flex flex-col md:flex-row lg:flex-col lg:items-start md:items-center md:justify-between gap-6 lg:gap-[20px] md:max-w-200 md:px-21 lg:px-0 md:mx-auto'>
+      <div className='flex flex-col md:flex-row lg:flex-col lg:items-start md:items-center md:justify-between gap-6 lg:gap-[20px] md:max-w-285 lg:max-w-200 md:px-21 lg:px-0 md:mx-auto'>
         <div className='flex justify-between items-center md:flex-wrap md:gap-y-5'>
           <div className='flex items-center gap-4 md:gap-5 md:grow-1 md:basis-[300px]'>
             <div className='text-4xl md:text-[54px] leading-[100%] font-extrabold'>

--- a/src/components/feature/keyboardDetails/ReviewCard.tsx
+++ b/src/components/feature/keyboardDetails/ReviewCard.tsx
@@ -36,7 +36,7 @@ const ReviewCard = ({ review }: Props) => {
   const UP_ARROW_ICON_URL = '/images/UpArrowIcon.svg';
 
   return (
-    <section className='relative border-1 border-gray-300 rounded-xl p-4 pb-2 md:px-10 md:pt-8 md:pb-5 w-full md:max-w-200'>
+    <section className='relative border-1 border-gray-300 rounded-xl p-4 pb-2 md:px-10 md:pt-8 md:pb-5 w-full md:max-w-285 lg:max-w-200'>
       <div className='flex justify-between items-start'>
         <div className='flex items-center gap-4'>
           <UserThumbnail className='w-[42px] md:w-16 h-[42px] md:h-16' imgSrc={image} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,9 @@
+'use client';
 import Link from 'next/link';
+
+import useSticky from '@/hooks/useSticky';
+import { cn } from '@/utils/style';
+
 import UserThumbnail from '../ui/UserThumbnail';
 
 interface HeaderProps {
@@ -6,22 +11,35 @@ interface HeaderProps {
   imgSrc?: string | null;
 }
 
+const STICKY_TOP = 0;
+
 const HeaderComponent = ({ loginStatus = false, imgSrc = null }: HeaderProps) => {
+  const { isFixedOnTop, stickyRef } = useSticky(STICKY_TOP);
+
   return (
-    // <header className='mx-auto my-5 flex  items-center justify-between bg-black rounded-2xl	 text-white px-[79px] py-[25px] '>
-    <header className='mx-4 lg:mx-auto my-5 flex lg:max-w-[1140px] items-center justify-between bg-black rounded-xl md:rounded-2xl text-white px-5 h-[50px] md:h-[70px] md:px-[60px]'>
-      <Link href='/' className='font-bold text-xl'>
-        tadak
-      </Link>
-      <div className='flex items-center gap-5 md:gap-10 font-medium text-md md:text-base'>
-        {loginStatus ? (
-          <UserThumbnail imgSrc={imgSrc} />
-        ) : (
-          <>
-            <Link href='/login'>로그인</Link>
-            <Link href='/signUp'>회원가입</Link>
-          </>
-        )}
+    <header
+      ref={stickyRef}
+      className={cn(
+        'flex sticky top-0 text-white transition-all duration-300 ease-in-out lg:w-285 bg-black rounded-xl md:rounded-2xl h-[50px] md:h-[70px] mx-4 lg:mx-auto my-5 px-5 md:px-15 z-999',
+        {
+          'rounded-none md:rounded-none lg:w-full px-9 md:px-19 mx-0': isFixedOnTop,
+        },
+      )}
+    >
+      <div className='flex items-center justify-between w-full lg:w-255 mx-auto'>
+        <Link href='/' className='font-bold text-xl'>
+          tadak
+        </Link>
+        <div className='flex items-center gap-5 md:gap-10 font-medium text-md md:text-base'>
+          {loginStatus ? (
+            <UserThumbnail imgSrc={imgSrc} />
+          ) : (
+            <>
+              <Link href='/login'>로그인</Link>
+              <Link href='/signUp'>회원가입</Link>
+            </>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/hooks/useSticky.ts
+++ b/src/hooks/useSticky.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const TABLET_WIDTH = 640;
+//targetY는 타겟 DOM요소가 sticky가 되는 뷰포트상의 y좌표입니다.
+const useSticky = (targetY: number, TabletTargetY?: number) => {
+  const [isFixedOnTop, setIsFixedOnTop] = useState(false);
+  const stickyRef = useRef<HTMLElement | null>(null);
+
+  const handleScroll = useCallback(() => {
+    if (!stickyRef.current) {
+      return;
+    }
+
+    const rect = stickyRef.current?.getBoundingClientRect();
+    //스크롤 이벤트 발생시 y값에 소수점 자리의 미세한 변동이 있을 수 있으므로 그 오차 허용값
+    const THRESHOLD = 1;
+    const currentViewport = window.innerWidth;
+    const isTabletView = currentViewport >= TABLET_WIDTH;
+
+    if (TabletTargetY && isTabletView) {
+      if (rect.y < TabletTargetY + THRESHOLD) {
+        setIsFixedOnTop(true);
+        return;
+      } else {
+        setIsFixedOnTop(false);
+        return;
+      }
+    }
+
+    if (rect.y < targetY + THRESHOLD) {
+      setIsFixedOnTop(true);
+      return;
+    } else {
+      setIsFixedOnTop(false);
+      return;
+    }
+  }, [targetY, TabletTargetY]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [handleScroll]);
+
+  return { isFixedOnTop, stickyRef };
+};
+
+export default useSticky;

--- a/src/hooks/useSticky.ts
+++ b/src/hooks/useSticky.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const TABLET_WIDTH = 640;
+
 //targetY는 타겟 DOM요소가 sticky가 되는 뷰포트상의 y좌표입니다.
-const useSticky = (targetY: number, TabletTargetY?: number) => {
+const useSticky = (targetY: number, tabletTargetY?: number) => {
   const [isFixedOnTop, setIsFixedOnTop] = useState(false);
   const stickyRef = useRef<HTMLElement | null>(null);
 
@@ -17,8 +18,8 @@ const useSticky = (targetY: number, TabletTargetY?: number) => {
     const currentViewport = window.innerWidth;
     const isTabletView = currentViewport >= TABLET_WIDTH;
 
-    if (TabletTargetY && isTabletView) {
-      if (rect.y < TabletTargetY + THRESHOLD) {
+    if (tabletTargetY && isTabletView) {
+      if (rect.y < tabletTargetY + THRESHOLD) {
         setIsFixedOnTop(true);
         return;
       } else {
@@ -34,7 +35,7 @@ const useSticky = (targetY: number, TabletTargetY?: number) => {
       setIsFixedOnTop(false);
       return;
     }
-  }, [targetY, TabletTargetY]);
+  }, [targetY, tabletTargetY]);
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);


### PR DESCRIPTION
## 작업 내역
close #152 

- 헤더 상단에 고정시 좌우로 꽉 차도록 변경했습니다.
- 해당 로직이 헤더와 상세페이지 두 곳에서 쓰여 훅으로 분리했습니다.
- 헤더 수정에 맞춰서 상세 페이지 스타일도 일부 수정했습니다.

## 스크린샷 (선택)
<img width="3902" height="1502" alt="localhost_3000_keyboards_1345 (4)" src="https://github.com/user-attachments/assets/b7db0eaa-caa2-4c48-ba54-a8ebe6bee1e0" />
<img width="1596" height="1470" alt="localhost_3000_keyboards_1345 (5)" src="https://github.com/user-attachments/assets/57d5bb2f-b957-4ec1-8f8a-46e85bc488d6" />
<img width="887" height="1473" alt="localhost_3000_keyboards_1345 (6)" src="https://github.com/user-attachments/assets/250cbc3c-0391-48ae-9454-2563ef66f4b7" />
