### PR TITLE
Refactor: 로그인, 회원가입 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,7 @@
 }
 
 @layer components {
+  /* input */
   .input {
     @apply w-full px-5 border py-2.5 text-md sm:rounded-xl
           md:py-3 md:text-base md:rounded-2xl
@@ -116,6 +117,7 @@
     @apply w-5 h-5 text-gray-500;
   }
 
+  /* form */
   .form {
     @apply flex flex-col items-center w-full md:w-[496px] bg-white px-5 py-14 md:px-12 md:py-16 rounded-2xl shadow-primary;
   }
@@ -124,6 +126,11 @@
     @apply flex flex-col w-full gap-4;
   }
 
+  .form-btm-link {
+    @apply flex gap-3.5 mt-10 text-sm md:text-base;
+  }
+
+  /* button */
   .btn-outlined {
     @apply !bg-white border border-gray-300 sm:rounded-xl hover:border-primary;
   }

--- a/src/components/feature/Form/SignInForm.tsx
+++ b/src/components/feature/Form/SignInForm.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { Field } from '@headlessui/react';
 import { AxiosError } from 'axios';
@@ -27,7 +27,6 @@ const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 const SignInForm = () => {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const auth = new AxiosApiAuth();
   const signIn = useAuthStore((state) => state.signIn);
   const addToast = useToastStore((state) => state.addToast);
@@ -45,16 +44,8 @@ const SignInForm = () => {
     try {
       const res = await auth.signInByEmail(email, password);
       const { user, accessToken, refreshToken } = res;
-      signIn({ user, accessToken, refreshToken }); // 유저 정보 zustand store에 저장
-
-      // 쿼리 파라미터에서 redirect_url 가져오기 (로그인 후 리다이렉트 처리)
-      const redirectUrl = searchParams.get('redirect_url');
-
-      if (redirectUrl) {
-        router.replace(redirectUrl);
-      } else {
-        router.push('/');
-      }
+      signIn({ user, accessToken, refreshToken }); // 유저 정보 store에 저장
+      router.push('/');
 
       addToast({
         message: (

--- a/src/components/feature/Form/SignInForm.tsx
+++ b/src/components/feature/Form/SignInForm.tsx
@@ -121,7 +121,7 @@ const SignInForm = () => {
         </Field>
       </div>
 
-      <div className='form-btm-actions'>
+      <div className='form-btm-actions pt-4 md:pt-8'>
         <ButtonDefault type='submit' disabled={!isValid || isSubmitting} className='w-full'>
           <span>로그인</span>
         </ButtonDefault>
@@ -129,7 +129,7 @@ const SignInForm = () => {
         <KakaoLoginButton />
       </div>
 
-      <div className='flex gap-3.5 text-sm md:text-base'>
+      <div className='form-btm-link'>
         <span className='text-gray-500'>계정이 없으신가요?</span>
         <Link href={SIGNUP_PAGE} className='text-primary underline underline-offset-4'>
           회원가입하기

--- a/src/components/feature/Form/SignUpForm.tsx
+++ b/src/components/feature/Form/SignUpForm.tsx
@@ -51,7 +51,15 @@ const SignInForm = () => {
       signIn({ user, accessToken, refreshToken }); // 유저 정보 zustand store에 저장
       await auth.signInByEmail(email, password); // 로그인 처리
 
-      addToast({ message: `환영해요, ${user.nickname}님!`, type: 'success', duration: 2000 });
+      addToast({
+        message: (
+          <span>
+            환영해요, <b>{user.nickname}</b>님!
+          </span>
+        ),
+        type: 'success',
+        duration: 2000,
+      });
       router.push('/');
     } catch (error) {
       const err = error as AxiosError;

--- a/src/components/feature/Form/SignUpForm.tsx
+++ b/src/components/feature/Form/SignUpForm.tsx
@@ -181,13 +181,13 @@ const SignInForm = () => {
         </Field>
       </div>
 
-      <div className='form-btm-actions'>
+      <div className='form-btm-actions pt-4 md:pt-8'>
         <ButtonDefault type='submit' disabled={!isValid || isSubmitting} className='w-full'>
           가입하기
         </ButtonDefault>
       </div>
 
-      <div className='flex gap-3.5 text-sm md:text-base'>
+      <div className='form-btm-link'>
         <span className='text-gray-500'>계정이 이미 있으신가요?</span>
         <Link href={SIGNIN_PAGE} className='text-primary underline underline-offset-4'>
           로그인하기

--- a/src/components/feature/KakaoLoginButton.tsx
+++ b/src/components/feature/KakaoLoginButton.tsx
@@ -11,7 +11,10 @@ const KakaoLoginButton = () => {
   };
 
   return (
-    <ButtonDefault onClick={handleLogin} className='w-full btn-outlined'>
+    <ButtonDefault
+      onClick={handleLogin}
+      className='w-full bg-white border border-gray-300 sm:rounded-xl hover:border-[#FEE500] hover:bg-[#FEE500]'
+    >
       <span className='relative w-6 h-6 rounded-full'>
         <Image src='/images/KakaoIcon.svg' alt='카카오톡 로고' fill={true} />
       </span>

--- a/src/components/feature/Keyboards/Filter/FilterModal.tsx
+++ b/src/components/feature/Keyboards/Filter/FilterModal.tsx
@@ -167,7 +167,7 @@ const FilterModal = ({
                   <FilterFooterButton onReset={onReset} onApply={onApply} />
                   <ButtonDefault
                     onClick={() => setKeyboardOpen(true)}
-                    className='hidden w-full h-[50px] mt-4 font-bold lg:block'
+                    className='hidden w-full mt-4 font-bold lg:block'
                   >
                     키보드 등록하기
                   </ButtonDefault>

--- a/src/components/feature/RequireAuth.tsx
+++ b/src/components/feature/RequireAuth.tsx
@@ -11,6 +11,7 @@ import { apiClient } from '@/lib/api/apiClient';
 import { AxiosApiAuth } from '@/lib/api/axios';
 import { tokenService } from '@/lib/api/tokenService';
 import useAuthStore from '@/stores/authStore';
+import useToastStore from '@/stores/toastStore';
 
 const PUBLIC_PATHS = ['/', KEYBOARD_LIST_PAGE];
 const AUTH_PATHS = [SIGNIN_PAGE, SIGNUP_PAGE, KAKAO_LOGIN_PAGE];
@@ -27,6 +28,8 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
 
   const router = useRouter();
   const pathname = usePathname();
+
+  const addToast = useToastStore((state) => state.addToast);
 
   // accessToken 재발급 + 재로그인 (user 전역 상태 저장): refreshToken 있을 때만 호출됨
   const refreshAccessTokenAndUser = useCallback(
@@ -86,28 +89,16 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
         return;
       }
 
-      // ✅ 로그인 권한 필요 없는 공개 페이지 (메인, 키보드 목록 페이지): 권한 검사 없이 바로 페이지 본문 리턴
+      // ✅ 로그인 필요 없는 공개 페이지 (메인, 키보드 목록 페이지): 권한 검사 없이 바로 페이지 본문 리턴
       if (isPublicPath) {
         setIsAuthChecked(true);
         return;
       }
 
-      // 로그인 권한 필요 페이지 (키보드 상세, 프로필 페이지)
-      if (!user) {
-        if (!refreshToken) {
-          const url = `${SIGNIN_PAGE}?redirect_url=${encodeURIComponent(pathname)}`; // 로그인 후 해당 페이지로 리다이렉트
-          router.replace(url);
-          return;
-        }
-
-        // !user && refreshToken
-        const success = await refreshAccessTokenAndUser(refreshToken);
-        if (!success) {
-          router.replace(SIGNIN_PAGE);
-          return;
-        }
-
-        setIsAuthChecked(true);
+      // ✅ 로그인 필요한 페이지 (키보드 상세, 내 프로필 페이지): 권한 없으면 로그인 페이지로 이동
+      if (!user && !refreshToken) {
+        router.replace(SIGNIN_PAGE);
+        addToast({ message: '로그인이 필요합니다.', type: 'error', duration: 2000 });
         return;
       }
 
@@ -115,7 +106,7 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
     };
 
     checkAndRefreshToken();
-  }, [pathname, router, user, refreshAccessTokenAndUser]);
+  }, [pathname, router, user, refreshAccessTokenAndUser, addToast]);
 
   if (!isAuthChecked)
     return isRefreshing ? <LoadingSpinner text='로그인 확인중...' className='h-screen' /> : null;

--- a/src/components/feature/RequireAuth.tsx
+++ b/src/components/feature/RequireAuth.tsx
@@ -31,7 +31,7 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
 
   const addToast = useToastStore((state) => state.addToast);
 
-  // accessToken 재발급 + 재로그인 (user 전역 상태 저장): refreshToken 있을 때만 호출됨
+  // accessToken 재발급 + user 전역 상태 갱신: refreshToken 있을 때만 호출
   const refreshAccessTokenAndUser = useCallback(
     async (refreshToken: string) => {
       const auth = new AxiosApiAuth();
@@ -95,11 +95,22 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
         return;
       }
 
-      // ✅ 로그인 필요한 페이지 (키보드 상세, 내 프로필 페이지): 권한 없으면 로그인 페이지로 이동
-      if (!user && !refreshToken) {
-        router.replace(SIGNIN_PAGE);
-        addToast({ message: '로그인이 필요합니다.', type: 'error', duration: 2000 });
-        return;
+      // // ✅ 로그인 필요한 페이지 (키보드 상세, 내 프로필 페이지): 권한 없으면 로그인 페이지로 이동
+      if (!user) {
+        if (!refreshToken) {
+          router.replace(SIGNIN_PAGE);
+          addToast({ message: '로그인이 필요합니다.', type: 'error', duration: 2000 });
+          return;
+        }
+
+        const success = await refreshAccessTokenAndUser(refreshToken);
+        if (!success) {
+          router.replace(SIGNIN_PAGE);
+          addToast({ message: '로그인이 필요합니다.', type: 'error', duration: 2000 });
+          return;
+        }
+
+        setIsAuthChecked(true);
       }
 
       setIsAuthChecked(true);

--- a/src/components/ui/ButtonDefault.tsx
+++ b/src/components/ui/ButtonDefault.tsx
@@ -88,12 +88,12 @@ const ButtonDefault = ({
    * - `transition-colors duration-200`: 배경색 변경 시 200ms 동안 부드러운 전환 효과를 적용합니다.
    */
   const baseStyles = `
-    w-[400px] h-[50px]
+    w-[400px] 
     flex flex-row justify-center items-center
-    py-4 px-[20px] gap-[10px]
-    bg-[#8642DB] rounded-2xl
+    py-3 px-[20px] gap-[10px]
+    bg-primary rounded-2xl
     text-white font-semibold
-    disabled:bg-gray-400 disabled:cursor-not-allowed
+    disabled:bg-gray-300 disabled:cursor-not-allowed 
     transition-colors duration-200
     hover:bg-primary-dark
   `;

--- a/src/components/ui/ButtonDefault.tsx
+++ b/src/components/ui/ButtonDefault.tsx
@@ -88,11 +88,10 @@ const ButtonDefault = ({
    * - `transition-colors duration-200`: 배경색 변경 시 200ms 동안 부드러운 전환 효과를 적용합니다.
    */
   const baseStyles = `
-    w-[400px] 
-    flex flex-row justify-center items-center
+    w-[400px] flex flex-row justify-center items-center
     py-3 px-[20px] gap-[10px]
     bg-primary rounded-2xl
-    text-white font-semibold
+    text-md md:text-base text-white font-semibold
     disabled:bg-gray-300 disabled:cursor-not-allowed 
     transition-colors duration-200
     hover:bg-primary-dark

--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -51,7 +51,7 @@ const ToastContainer = () => {
   if (!overlayRoot) return null;
 
   return createPortal(
-    <div className='fixed left-1/2 -translate-x-1/2 bottom-9 z-60 whitespace-nowrap'>
+    <div className='fixed flex flex-col gap-2 left-1/2 -translate-x-1/2 bottom-9 z-60 whitespace-nowrap'>
       {toasts.map((t) => (
         <div
           key={t.id}

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
 
-import { SIGNIN_PAGE } from '@/constants';
 import useAuthStore from '@/stores/authStore';
 
 import { AxiosApiAuth } from './axios';

--- a/src/lib/api/apiClient.ts
+++ b/src/lib/api/apiClient.ts
@@ -44,13 +44,10 @@ apiClient.interceptors.response.use(
           // 재발급 실패 시 토큰 삭제 후 로그인 페이지 이동 처리
           signOut(); // 유저 전역 상태 null
           auth.signOut(); // 토큰만 따로 삭제
-          window.location.href = SIGNIN_PAGE;
 
           return Promise.reject(error);
         }
       } else {
-        // refreshToken 없으면 바로 로그인 페이지로
-        window.location.href = SIGNIN_PAGE;
         return Promise.reject(error);
       }
     }


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- [x] 로그인하지 않은 상태로 목록페이지에서 키보드 카드를 누르면, 로그인 페이지로 리다이렉팅이 연속 두 번 되는것 같습니다. https://tadak.alex-choi.com/login?redirect_url=%2Fkeyboards%2F1446 → https://tadak.alex-choi.com/login 이 두 url이 빠르게 연속으로 이동하기 때문에, 도착한 로그인 페이지에서 뒤로 가기 두번을 눌러야 다시 목록 페이지로 돌아올 수 있습니다.
- [x] 사소한건데 signup 루트 폴더명이 카멜케이스로 작성되어서 signUp이 경로로 되어있네요! 경로는 소문자로 통일하는게 어떨까 합니다
- [x] 버튼과 안내 문구 여백
- [x] 회원가입 성공 토스트: 로그인 성공 토스트와 스타일 통일 (닉네임 볼드 처리)
- [x] 현재 토스트 없이 자동 리다이렉트 처리만 되어있음. 키보드 상세, 프로필 페이지 접근 시 토스트 추가 필요
- 추가 작업:
  - `ButtonDefault` 반응형 추가 (모바일에서 폰트 14px 처리) 

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->
- 브랜치명은 흐린눈 해주세여..🙏 대충 지어버렸네여

## 스크린샷 (선택)
