### PR TITLE
Refactor: 목록 페이지 슬라이더, 라우팅 수정

### DIFF
--- a/src/app/(global)/keyboards/page.tsx
+++ b/src/app/(global)/keyboards/page.tsx
@@ -64,7 +64,7 @@ const KeyboardsPage = () => {
       const res = await apiClient.post(`/${TEAM_ID}/wines`, payload);
       const data = res?.data;
 
-      router.replace(`/keyboards/${data.id}`);
+      router.push(`/keyboards/${data.id}`);
     } catch (err) {
       throw err;
     }

--- a/src/components/feature/Slider/SliderSection.tsx
+++ b/src/components/feature/Slider/SliderSection.tsx
@@ -26,7 +26,7 @@ const SliderSection = ({ title }: { title?: string | ReactNode }) => {
 
   return (
     <section className='w-full'>
-      <article className='bg-gray-100 p-5 md:p-[30px] rounded-xl md:rounded-2xl'>
+      <article className='bg-gray-100 py-5 pl-5 pr-0 md:py-[30px] md:pl-[30px] rounded-xl md:rounded-2xl'>
         {title && <h4 className='text-lg md:text-xl font-bold mb-5 md:mb-[30px]'>{title}</h4>}
         {!isError ? <ListSlider items={items} /> : <p>추천 데이터 가져오기에 실패했습니다.</p>}
       </article>

--- a/src/components/feature/Slider/index.tsx
+++ b/src/components/feature/Slider/index.tsx
@@ -33,6 +33,7 @@ const ListSlider = ({ items }: ItemsProps) => {
   return (
     <div className='relative'>
       <Swiper
+        className='!pr-5 md:!pr-[30px]'
         slidesPerView='auto'
         spaceBetween={16}
         loop={false}

--- a/src/components/feature/Slider/index.tsx
+++ b/src/components/feature/Slider/index.tsx
@@ -73,14 +73,14 @@ const ListSlider = ({ items }: ItemsProps) => {
           icon={RightArrowIcon}
           iconReverse
           rounded
-          className='absolute left-5 shadow-md'
+          className='absolute left-2 md:left-5 shadow-md'
           disabled={isBeginning}
           onClick={() => swiperRef.current?.slidePrev()}
         />
         <IconButton
           icon={RightArrowIcon}
           rounded
-          className='absolute right-5 shadow-md'
+          className='absolute right-2 md:right-5 shadow-md'
           disabled={isEnd}
           onClick={() => swiperRef.current?.slideNext()}
         />

--- a/src/components/feature/keyboardDetails/KeyboardMiniCard.tsx
+++ b/src/components/feature/keyboardDetails/KeyboardMiniCard.tsx
@@ -15,7 +15,12 @@ const KeyboardMiniCard = ({ item }: KeyboardMiniItem) => {
         <div className='shrink-0 w-[52px] md:w-[60px] mt-[130%] md:mt-[118%]'>
           <div className='relative'>
             <figure className='absolute bottom-0 rotate-90 right-full origin-bottom-right w-[180px] aspect-[160/44] md:w-[200px] md:aspect-[184/56]'>
-              <Image src={item.image} alt={item.name} fill />
+              <Image
+                src={item.image}
+                alt={item.name}
+                fill
+                sizes={`(max-width: 639px) 50px, 60px`}
+              />
             </figure>
           </div>
         </div>


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- [x] 슬라이더 여백
- [x] 키보드 등록 하기 성공시 상세페이지로 이동 후 뒤로가기 하면, 랜딩페이지로 이동 됨. 목록 페이지로 이동 되는 것이 맞는거 같습니다.
- [x] 슬라이더 키보드 이미지 Fill + sizes 속성 추가 (개발 모드에서 경고뜸)
- [x] 화살표 버튼 반응형: 모바일에서 더 바깥쪽으로 빼기 

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

## 스크린샷 (선택)
