### PR TITLE
fix: 가격 필터 슬라이더 초기화 안되는 문제 수정

### DIFF
--- a/src/components/feature/Keyboards/Filter/FilterContent.tsx
+++ b/src/components/feature/Keyboards/Filter/FilterContent.tsx
@@ -19,7 +19,7 @@ import type { KeyboardCategoryType } from '@/types/keyboardTypes';
 
 interface FilterModalProps {
   open: boolean;
-  onClose: (trigger: boolean) => void;
+  onClose: () => void;
   // selectedType: KeyboardCategoryType | null;
   // onToggleType: (type: KeyboardCategoryType) => void;
   onReset: () => void;
@@ -41,13 +41,14 @@ const FilterContent = ({ open, onClose, onReset, onApply, setKeyboardOpen }: Fil
   const [type, setType] = useState<KeyboardCategoryType | null>(null);
   const [price, setPrice] = useState<[number, number]>([0, 300000]);
   const [rating, setRating] = useState<number | null>(null);
+  const [resetTrigger, setResetTrigger] = useState(0);
 
   const innerWidth = useWindowWidth();
   const isWeb = innerWidth >= 1280;
   const isModalOpenOrWeb = open || isWeb;
   const handleClose = () => {
     if (isWeb) return;
-    onClose(false);
+    onClose();
   };
   const ref = useOutsideClick(handleClose);
 
@@ -62,7 +63,7 @@ const FilterContent = ({ open, onClose, onReset, onApply, setKeyboardOpen }: Fil
 
   useEffect(() => {
     if (open && isWeb) {
-      onClose(false);
+      onClose();
     }
   }, [isWeb, open, onClose]);
 
@@ -72,6 +73,7 @@ const FilterContent = ({ open, onClose, onReset, onApply, setKeyboardOpen }: Fil
     setType(null);
     setPrice([0, 300000]);
     setRating(null);
+    setResetTrigger((prev) => prev + 1);
   };
 
   // 필터 적용 함수
@@ -83,6 +85,7 @@ const FilterContent = ({ open, onClose, onReset, onApply, setKeyboardOpen }: Fil
       maxPrice,
       rating,
     });
+    onClose();
   };
 
   return (
@@ -145,6 +148,7 @@ const FilterContent = ({ open, onClose, onReset, onApply, setKeyboardOpen }: Fil
                         className='lg:w-[80%]'
                         initialValue={price}
                         onChange={setPrice}
+                        resetTrigger={resetTrigger}
                       />
                     </div>
                   </section>

--- a/src/components/ui/RangeSlider/MultihandleSlider.tsx
+++ b/src/components/ui/RangeSlider/MultihandleSlider.tsx
@@ -14,8 +14,9 @@ const MINIMUM_HANDLE_GAP = 20; // 전체 트랙 길이 300중 20
 
 const MultihandleSlider = ({
   className,
-  initialValue = [0, 300],
+  initialValue,
   onChange,
+  resetTrigger,
 }: MultihandleSliderProps) => {
   const [minValue, setMinValue] = useState(initialValue[0] / 1000);
   const [maxValue, setMaxValue] = useState(initialValue[1] / 1000);
@@ -26,6 +27,7 @@ const MultihandleSlider = ({
   const maxHandleStyle = { left: `${(maxValue / 300) * 100}%` };
   const minPrice = `￦ ${formatPrice(1000 * minValue)}`;
   const maxPrice = `￦ ${formatPrice(1000 * maxValue)}`;
+  const isMountFlag = useRef(true);
 
   const handleMouseDown = (event: React.MouseEvent | MouseEvent) => {
     isDragging.current = true;
@@ -59,11 +61,13 @@ const MultihandleSlider = ({
       }
       //핸들이 트랙의 끝에 있을 때, 드래그를 해도 값이 바뀌지 않으면 상태 업데이트를 하지않도록 설정
       setMinValue((prev) => (prev === value ? prev : value));
+      onChange([1000 * value, 1000 * maxValue]);
     } else if (activeHandleRef.current === 'max') {
       if (Math.abs(value - minValue) < MINIMUM_HANDLE_GAP || value < minValue) {
         return;
       }
       setMaxValue((prev) => (prev === value ? prev : value));
+      onChange([1000 * minValue, 1000 * value]);
     }
   };
 
@@ -105,11 +109,13 @@ const MultihandleSlider = ({
         return;
       }
       setMinValue((prev) => (prev === value ? prev : value));
+      onChange([1000 * value, 1000 * maxValue]);
     } else if (activeHandleRef.current === 'max') {
       if (Math.abs(value - minValue) < MINIMUM_HANDLE_GAP || value < minValue) {
         return;
       }
       setMaxValue((prev) => (prev === value ? prev : value));
+      onChange([1000 * minValue, 1000 * value]);
     }
   };
 
@@ -119,10 +125,14 @@ const MultihandleSlider = ({
     window.removeEventListener('touchend', handleTouchEnd);
   };
 
-  //마운트시 초기값 전달
   useEffect(() => {
-    onChange([1000 * minValue, 1000 * maxValue]);
-  }, [minValue, maxValue]);
+    if (isMountFlag.current) {
+      isMountFlag.current = false;
+      return;
+    }
+    setMinValue(0);
+    setMaxValue(300);
+  }, [resetTrigger]);
 
   if (!RangesliderRef) {
     return;

--- a/src/types/rangeSliderTypes.d.ts
+++ b/src/types/rangeSliderTypes.d.ts
@@ -26,4 +26,5 @@ export interface MultihandleSliderProps {
   className?: string;
   initialValue: [number, number];
   onChange: (range: [number, number]) => void;
+  resetTrigger: number;
 }


### PR DESCRIPTION
## 작업 내역
스트릭트 모드가 켜져있을 때에는 모달을 나갔다 들어왔을 때 가격 설정값이 유지되지 않습니다. 배포 환경에서는 잘 동작 할겁니다!
