### PR TITLE
Style: 키보드 타이틀 영역 break-words 적용

### DIFF
--- a/src/app/(global)/slider/page.tsx
+++ b/src/app/(global)/slider/page.tsx
@@ -1,7 +1,0 @@
-import SliderSection from '@/components/feature/Slider/SliderSection';
-
-const SliderPage = () => {
-  return <SliderSection title='이번 달 추천 키보드' />;
-};
-
-export default SliderPage;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -182,6 +182,11 @@
   .link {
     @apply py-1 px-2.5 md:py-2.5 md:px-4 hover:bg-white hover:text-black rounded-lg transition-colors;
   }
+
+  /* tailwind 'break-words' 레거시 css 적용 */
+  .break-word-legacy {
+    word-break: break-word;
+  }
 }
 
 @layer base {

--- a/src/components/feature/Keyboards/IndexKeyboardsCard.tsx
+++ b/src/components/feature/Keyboards/IndexKeyboardsCard.tsx
@@ -51,7 +51,9 @@ const IndexKeyboardsCard = ({
         {/* 본문 컨텐츠 */}
         <div className='pt-[30px] pr-5 pb-7 grow md:flex md:gap-[45px] md:pt-10 md:pr-10 md:pb-6 lg:pt-9 lg:pr-[53px] lg:pb-6 lg:gap-[70px]'>
           <div className='grow-1'>
-            <h3 className='text-xl font-semibold line-clamp-2 md:mb-5 md:text-3xl'>{name}</h3>
+            <h3 className='text-xl font-semibold line-clamp-2 md:mb-5 md:text-3xl break-word-legacy'>
+              {name}
+            </h3>
             <span className='block mb-2 text-md text-gray-500 md:mb-3 md:text-base lg:mb-4'>
               {region}
             </span>


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- 키보드 타이틀 영역에 `word-break: break-words`를 적용하여 '111111111111111'과 같은 제목일 때 영역을 벗어나지 않도록 방지
  - 테일윈드 기본 유틸 클래스 `break-words` 사용 시 `overflow-wrap: break-word;`로 변환되는데, 여전히 영역을 벗어나서 기존 css 코드인 `word-break: break-word;`를 `break-word-legacy`라는 커스텀 클래스로 추가하여 적용 

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

## 스크린샷 (선택)
#### [before]
<img width="500" alt="before" src="https://github.com/user-attachments/assets/d32fa5a3-b6cc-49bb-a3de-2ce5b941f249" />

#### [after]
<img width="500" alt="after" src="https://github.com/user-attachments/assets/dc28eda9-c1bc-439d-ba27-5d5d28b904df" />

